### PR TITLE
Remove `enabled` field from rules

### DIFF
--- a/rules/proc_creation_win_agentexecutor_potential_abuse.yml
+++ b/rules/proc_creation_win_agentexecutor_potential_abuse.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: AgentExecutor PowerShell Execution
-enabled: true
 description: |-
   Detects execution of the AgentExecutor.exe binary. Which can be abused as a LOLBIN to execute powershell scripts with the ExecutionPolicy "Bypass" or any binary named "powershell.exe" located in the path provided by 6th positional argument
 

--- a/rules/proc_creation_win_agentexecutor_susp_usage.yml
+++ b/rules/proc_creation_win_agentexecutor_susp_usage.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: Suspicious AgentExecutor PowerShell Execution
-enabled: true
 description: |-
   Detects execution of the AgentExecutor.exe binary. Which can be abused as a LOLBIN to execute powershell scripts with the ExecutionPolicy "Bypass" or any binary named "powershell.exe" located in the path provided by 6th positional argument
 

--- a/rules/proc_creation_win_bcp_export_data.yml
+++ b/rules/proc_creation_win_bcp_export_data.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: Data Export From MSSQL Table Via BCP.EXE
-enabled: true
 description: |-
   Detects the execution of the BCP utility in order to export data from the database.
   Attackers were seen saving their malware to a database column or table and then later extracting it via "bcp.exe" into a file.

--- a/rules/proc_creation_win_bitlockertogo_execution.yml
+++ b/rules/proc_creation_win_bitlockertogo_execution.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: BitLockerTogo.EXE Execution
-enabled: true
 description: |-
   Detects the execution of "BitLockerToGo.EXE".
   BitLocker To Go is BitLocker Drive Encryption on removable data drives. This feature includes the encryption of, USB flash drives, SD cards, External hard disk drives, Other drives that are formatted by using the NTFS, FAT16, FAT32, or exFAT file system.

--- a/rules/proc_creation_win_conhost_headless_powershell.yml
+++ b/rules/proc_creation_win_conhost_headless_powershell.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: Powershell Executed From Headless ConHost Process
-enabled: true
 description: |-
   Detects the use of powershell commands from headless ConHost window.
   The "--headless" flag hides the windows from the user upon execution.

--- a/rules/proc_creation_win_diskshadow_script_mode_susp_location.yml
+++ b/rules/proc_creation_win_diskshadow_script_mode_susp_location.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: Diskshadow Script Mode - Execution From Potential Suspicious Location
-enabled: true
 description: |-
   Detects execution of "Diskshadow.exe" in script mode using the "/s" flag where the script is located in a potentially suspicious location.
 

--- a/rules/proc_creation_win_dump64_defender_av_bypass_rename.yml
+++ b/rules/proc_creation_win_dump64_defender_av_bypass_rename.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: Potential Windows Defender AV Bypass Via Dump64.EXE Rename
-enabled: true
 description: |-
   Detects when a user is potentially trying to bypass the Windows Defender AV by renaming a tool to dump64.exe and placing it in the Visual Studio folder.
   Currently the rule is covering only usage of procdump but other utilities can be added in order to increase coverage.

--- a/rules/proc_creation_win_finger_execution.yml
+++ b/rules/proc_creation_win_finger_execution.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: Finger.EXE Execution
-enabled: true
 description: |-
   Detects execution of the "finger.exe" utility.
   Finger.EXE or "TCPIP Finger Command" is an old utility that is still present on modern Windows installation. It Displays information about users on a specified remote computer (typically a UNIX computer) that is running the finger service or daemon.

--- a/rules/proc_creation_win_hktl_krbrelay_remote.yml
+++ b/rules/proc_creation_win_hktl_krbrelay_remote.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: HackTool - RemoteKrbRelay Execution
-enabled: true
 description: |-
   Detects the use of RemoteKrbRelay, a Kerberos relaying tool via CommandLine flags and PE metadata.
 

--- a/rules/proc_creation_win_hktl_lazagne.yml
+++ b/rules/proc_creation_win_hktl_lazagne.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: HackTool - LaZagne Execution
-enabled: true
 description: |-
   Detects the execution of the LaZagne. A utility used to retrieve multiple types of passwords stored on a local computer.
   LaZagne has been leveraged multiple times by threat actors in order to dump credentials.

--- a/rules/proc_creation_win_hktl_sharp_dpapi_execution.yml
+++ b/rules/proc_creation_win_hktl_sharp_dpapi_execution.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: HackTool - SharpDPAPI Execution
-enabled: true
 description: |-
   Detects the execution of the SharpDPAPI tool based on CommandLine flags and PE metadata.
   SharpDPAPI is a C# port of some DPAPI functionality from the Mimikatz project.

--- a/rules/proc_creation_win_kavremover_uncommon_execution.yml
+++ b/rules/proc_creation_win_kavremover_uncommon_execution.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: Kavremover Dropped Binary LOLBIN Usage
-enabled: true
 description: |-
   Detects the execution of a signed binary dropped by Kaspersky Lab Products Remover (kavremover) which can be abused as a LOLBIN to execute arbitrary commands and binaries.
 

--- a/rules/proc_creation_win_link_uncommon_parent_process.yml
+++ b/rules/proc_creation_win_link_uncommon_parent_process.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: Uncommon Link.EXE Parent Process
-enabled: true
 description: |-
   Detects an uncommon parent process of "LINK.EXE".
   Link.EXE in Microsoft incremental linker. Its a utility usually bundled with Visual Studio installation.

--- a/rules/proc_creation_win_mstsc_remote_connection.yml
+++ b/rules/proc_creation_win_mstsc_remote_connection.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: New Remote Desktop Connection Initiated Via Mstsc.EXE
-enabled: true
 description: |-
   Detects the usage of "mstsc.exe" with the "/v" flag to initiate a connection to a remote server.
   Adversaries may use valid accounts to log into a computer using the Remote Desktop Protocol (RDP). The adversary may then perform actions as the logged-on user.

--- a/rules/proc_creation_win_powershell_dsinternals_cmdlets.yml
+++ b/rules/proc_creation_win_powershell_dsinternals_cmdlets.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: DSInternals Suspicious PowerShell Cmdlets
-enabled: true
 description: |-
   Detects execution and usage of the DSInternals PowerShell module. Which can be used to perform what might be considered as suspicious activity such as dumping DPAPI backup keys or manipulating NTDS.DIT files.
   The DSInternals PowerShell Module exposes several internal features of Active Directory and Azure Active Directory. These include FIDO2 and NGC key auditing, offline ntds.dit file manipulation, password auditing, DC recovery from IFM backups and password hash calculation.

--- a/rules/proc_creation_win_qemu_suspicious_execution.yml
+++ b/rules/proc_creation_win_qemu_suspicious_execution.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: Potentially Suspicious Usage Of Qemu
-enabled: true
 description: |-
   Detects potentially suspicious execution of the Qemu utility in a Windows environment.
   Threat actors have leveraged this utility and this technique for achieving network access as reported by Kaspersky.

--- a/rules/proc_creation_win_renamed_boinc.yml
+++ b/rules/proc_creation_win_renamed_boinc.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: Renamed BOINC Client Execution
-enabled: true
 description: |-
   Detects the execution of a renamed BOINC binary.
 

--- a/rules/proc_creation_win_renamed_msteams.yml
+++ b/rules/proc_creation_win_renamed_msteams.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: Renamed Microsoft Teams Execution
-enabled: true
 description: |-
   Detects the execution of a renamed Microsoft Teams binary.
 

--- a/rules/proc_creation_win_renamed_sysinternals_procdump.yml
+++ b/rules/proc_creation_win_renamed_sysinternals_procdump.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: Renamed ProcDump Execution
-enabled: true
 description: |-
   Detects the execution of a renamed ProcDump executable.
   This often done by attackers or malware in order to evade defensive mechanisms.

--- a/rules/proc_creation_win_rundll32_udl_exec.yml
+++ b/rules/proc_creation_win_rundll32_udl_exec.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: Potentially Suspicious Rundll32.EXE Execution of UDL File
-enabled: true
 description: |-
   Detects the execution of rundll32.exe with the oledb32.dll library to open a UDL file.
   Threat actors can abuse this technique as a phishing vector to capture authentication credentials or other sensitive data.

--- a/rules/proc_creation_win_setres_uncommon_child_process.yml
+++ b/rules/proc_creation_win_setres_uncommon_child_process.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: Uncommon Child Process Of Setres.EXE
-enabled: true
 description: |-
   Detects uncommon child process of Setres.EXE.
   Setres.EXE is a Windows server only process and tool that can be used to set the screen resolution.

--- a/rules/proc_creation_win_susp_electron_app_children.yml
+++ b/rules/proc_creation_win_susp_electron_app_children.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: Suspicious Electron Application Child Processes
-enabled: true
 description: |-
   Detects suspicious child processes of electron apps (teams, discord, slack, etc.). This could be a potential sign of ".asar" file tampering (See reference section for more information) or binary execution proxy through specific CLI arguments (see related rule)
 

--- a/rules/proc_creation_win_susp_etw_trace_evasion.yml
+++ b/rules/proc_creation_win_susp_etw_trace_evasion.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: ETW Trace Evasion Activity
-enabled: true
 description: |-
   Detects command line activity that tries to clear or disable any ETW trace log which could be a sign of logging evasion.
 

--- a/rules/proc_creation_win_susp_no_image_name.yml
+++ b/rules/proc_creation_win_susp_no_image_name.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: Process Launched Without Image Name
-enabled: true
 description: |-
   Detect the use of processes with no name (".exe"), which can be used to evade Image-based detections.
 

--- a/rules/proc_creation_win_susp_system_exe_anomaly.yml
+++ b/rules/proc_creation_win_susp_system_exe_anomaly.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: System File Execution Location Anomaly
-enabled: true
 description: |-
   Detects the execution of a Windows system binary that is usually located in the system folder from an uncommon location.
 

--- a/rules/proc_creation_win_svchost_masqueraded_execution.yml
+++ b/rules/proc_creation_win_svchost_masqueraded_execution.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: Suspicious Process Masquerading As SvcHost.EXE
-enabled: true
 description: |-
   Detects a suspicious process that is masquerading as the legitimate "svchost.exe" by naming its binary "svchost.exe" and executing from an uncommon location.
   Adversaries often disguise their malicious binaries by naming them after legitimate system processes like "svchost.exe" to evade detection.


### PR DESCRIPTION
Support staging state for out-of-the-box rules. The enabled flag should not take precedence when users add rules with staging state.